### PR TITLE
fix: Content changes. Remove back from step1. Fix document field caption

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -65,8 +65,8 @@ class Account < ApplicationRecord
 
   def create_document_types
     [
-      { file_type: 'image', title: 'Фотография или скан действительного документа, удостоверяющего личность', placeholder_photo: 'photo-doc-example-1@2x.png', position: 1, calculate_similarity: false },
-      { file_type: 'image', title: 'Селфи с документом и листком бумаги, с текущей датой и фразой «для криптобанка Bitzlato»', placeholder_photo: 'photo-doc-example-2@2x.png', calculate_similarity: true, position: 2 }
+      { file_type: 'image', title: 'Загрузите фотографию или скан действительного документа, удостоверяющего личность', placeholder_photo: 'photo-doc-example-1@2x.png', position: 1, calculate_similarity: false },
+      { file_type: 'image', title: 'Загрузите селфи с документом и листком бумаги, с текущей датой и фразой «для криптобанка Bitzlato»', placeholder_photo: 'photo-doc-example-2@2x.png', calculate_similarity: true, position: 2 }
     ].each do |attributes|
       document_types.create!(attributes)
     end

--- a/app/views/client/verifications/_document_field_mobile.slim
+++ b/app/views/client/verifications/_document_field_mobile.slim
@@ -15,11 +15,11 @@ div id="#{element_id}" data-file-input=""
   div data-controls=""
     .d-flex
       label.btn.btn-primary.flex-grow-1.mr-4
-        input.custom-file-input.position-absolute type="file"  capture="user" style="height: 0" data-index=document.index value=document.object.file name=document.object_name+'[file]' accept=document.object.document_type.content_types.join(',') data-input=""
+        input.custom-file-input.position-absolute type="file" capture="filesystem" style="height: 0" data-index=document.index value=document.object.file name=document.object_name+'[file]' accept=document.object.document_type.content_types.join(',') data-input=""
         = 'Загрузить файл'
 
       label.btn.btn-primary.flex-grow-1
-        input.custom-file-input.position-absolute type="file"  capture="user" style="height: 0" data-input=""
+        input.custom-file-input.position-absolute type="file" capture="user" style="height: 0" data-input=""
         = 'Открыть камеру'
 
   div style="display: none" data-filename-container=""

--- a/app/views/client/verifications/new.html+mobile.slim
+++ b/app/views/client/verifications/new.html+mobile.slim
@@ -16,7 +16,7 @@
       li.font-weight-semibold.text-primary.py-1
         span.text-body Сделать фото действительного документа, удостоверяющего личность
       li.font-weight-semibold.text-primary.py-1
-        span.text-body Сделать селфи с документом и листком бумаги, где написаны текущая дата и "Bitzlato"
+        span.text-body Сделать селфи с документом и листком бумаги, где написаны текущая дата и "для криптобанка Bitzlato"
 
     .d-flex.align-items-center.justify-content-center.my-3
       .px-4

--- a/app/views/client/verifications/step1.html+mobile.slim
+++ b/app/views/client/verifications/step1.html+mobile.slim
@@ -27,7 +27,6 @@
 
   .container.fixed-bottom.pb-4.d-flex
     = f.input :next_step, as: :hidden, input_html: { value: 2 }
-    button type="submit" value='back' name='submit' class='btn btn-outline-primary font-weight-semibold w-100 mr-4' style='max-width: 130px' Назад
     = f.submit 'Продолжить', class: 'btn btn-primary w-100', data: { 'disable-with' => 'Отправляю..' }
 
 .mb-5.pb-5


### PR DESCRIPTION
- на шаге 3 на “Загрузить файл” не кидает в галерею, отправляет тоже в камеру
- На шаге 3 заменить тайтл как в дизайне на “Загрузиту фотографию или скан действительного документа, удостоверяющего личность”
- заменить на заглавной странице 4 пункт, а именно вместо “Bitzlato” заменить “для криптобанка Bitzlato”
- Убрать кнопку “Назад” в первом шаге
